### PR TITLE
Join CASA as Tally Representative

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Below, please find a list of all members and their organizations.
 | :------------ | :------ | :----- | :------------- |
 | ChainAgnostic | Ligi ([@ligi](https://github.com/ligi)), Pedro Gomes ([@pedrouid](https://github.com/pedrouid)), Antoine Herzog ([@antoineherzog](https://github.com/antoineherzog)) | Maintainer | All Working groups |
 | [Epicenter](https://epicenter.tv) | Sebastien Couture ([@seb2point0](https://github.com/seb2point0)) | Member     | CAIPs discussion   |
+| Tally | Tarrence ([@tarrencev](https://github.com/tarrencev)) | Maintainer (go-caip) | All Working groups |
 
 <a name="Join"></a>
 


### PR DESCRIPTION
Hi, I would like to join CASA as a representative from [Tally](https://withtally.com). We are utilizing CAIP identifiers extensively as we work to support cross chain governance. Additionally, I would be interested in driving standardization around canonical governance identifiers if that is within the scope of CAIP.